### PR TITLE
#22 fix: add expected's mutex unlock call in case the Exec query doesn't match but there are other expectations in the queue

### DIFF
--- a/clickconnmock.go
+++ b/clickconnmock.go
@@ -406,6 +406,7 @@ func (c *clickhousemock) Exec(ctx context.Context, query string, args ...any) er
 	}
 
 	if err := c.queryMatcherFunc().Match(expected.expectSQL, query); err != nil {
+		expected.Unlock()
 		return fmt.Errorf("call to database Exec with unexpected query: %s", query)
 	}
 


### PR DESCRIPTION
More context in #22 :

https://github.com/srikanthccv/ClickHouse-go-mock/issues/22#issue-2369305454