### PR TITLE
feat: add support for WillReturnRows on ExpectSelect

### DIFF
--- a/expectations.go
+++ b/expectations.go
@@ -221,7 +221,7 @@ func matchArg(expected, actual any) error {
 	if reflect.DeepEqual(expected, actual) {
 		return nil
 	}
-	return fmt.Errorf("expected %v, got %v", expected, actual)
+	return fmt.Errorf("expected %v (%T), got %v (%T)", expected, expected, actual, actual)
 }
 
 // ExpectedPing is used to manage *driver.Conn.Ping expectations.
@@ -596,6 +596,12 @@ type ExpectedSelect struct {
 	commonExpectation
 	expectSQL string
 	delay     time.Duration
+	rows      *Rows
+}
+
+func (e *ExpectedSelect) WillReturnRows(rows *Rows) *ExpectedSelect {
+	e.rows = rows
+	return e
 }
 
 // WillReturnError allows to set an error for the expected *Conn.Select action.

--- a/rows.go
+++ b/rows.go
@@ -64,14 +64,12 @@ func (r *Rows) ScanStruct(dest any) error {
 	if r.pos >= len(r.values) {
 		return io.EOF
 	}
-	if err := scan(r.block, r.pos, r.structMap, dest); err != nil {
+
+	values, err := r.structMap.Map("ScanStruct", r.Columns(), dest, true)
+	if err != nil {
 		return err
 	}
-	if err := r.nextErr[r.pos]; err != nil {
-		return err
-	}
-	r.pos++
-	return nil
+	return r.Scan(values...)
 }
 
 func (r *Rows) Totals(dest ...any) error {

--- a/rows.go
+++ b/rows.go
@@ -65,6 +65,7 @@ func (r *Rows) ScanStruct(dest any) error {
 		return io.EOF
 	}
 
+	// Based on implementation of rows.ScanStruct in clickhouse-go https://github.com/ClickHouse/clickhouse-go/blob/main/clickhouse_rows.go#L81
 	values, err := r.structMap.Map("ScanStruct", r.Columns(), dest, true)
 	if err != nil {
 		return err


### PR DESCRIPTION
Adds support for using WillReturnRows with ExpectSelect for doing things like
```
mockClickhouse.ExpectSelect(expectedSelectSQL).WillReturnRows(mockhouse.NewRows(cols, values))
```