### PR TITLE
fix: prevent nil pointer dereference in NewRows for DateTime columns

### DIFF
--- a/clickconnmock.go
+++ b/clickconnmock.go
@@ -194,7 +194,7 @@ func (c *clickhousemock) Close() error {
 		if fulfilled == len(c.expected) {
 			msg = "all expectations were already fulfilled, " + msg
 		}
-		return fmt.Errorf(msg)
+		return fmt.Errorf("%s", msg)
 	}
 
 	expected.triggered = true
@@ -282,7 +282,7 @@ func (c *clickhousemock) Ping(ctx context.Context) error {
 		if fulfilled == len(c.expected) {
 			msg = "all expectations were already fulfilled, " + msg
 		}
-		panic(fmt.Errorf(msg))
+		panic(fmt.Errorf("%s", msg))
 	}
 
 	expected.triggered = true
@@ -403,7 +403,7 @@ func (c *clickhousemock) Exec(ctx context.Context, query string, args ...any) er
 		if fulfilled == len(c.expected) {
 			msg = "all expectations were already fulfilled, " + msg
 		}
-		return fmt.Errorf(msg)
+		return fmt.Errorf("%s", msg)
 	}
 
 	if err := c.queryMatcherFunc().Match(expected.expectSQL, query); err != nil {
@@ -776,7 +776,7 @@ func (c *clickhousemock) ServerVersion() (*driver.ServerVersion, error) {
 		if fulfilled == len(c.expected) {
 			msg = "all expectations were already fulfilled, " + msg
 		}
-		return &driver.ServerVersion{}, fmt.Errorf(msg)
+		return &driver.ServerVersion{}, fmt.Errorf("%s", msg)
 	}
 
 	expected.triggered = true

--- a/clickconnmock_test.go
+++ b/clickconnmock_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestPrepareExpectations(t *testing.T) {
@@ -647,5 +648,49 @@ func TestQueryReturnRowCustomError(t *testing.T) {
 
 	if err.Error() != "some error" {
 		t.Errorf("expected error to be some error, but got %s", err)
+	}
+}
+
+func TestNewRowsWithDateTimeColumn(t *testing.T) {
+	t.Parallel()
+	mock, err := NewClickHouseNative(nil)
+	if err != nil {
+		t.Errorf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+
+	cols := []ColumnType{
+		{Type: "String", Name: "name"},
+		{Type: "DateTime", Name: "created_at"},
+	}
+	now := time.Now().Truncate(time.Second)
+	values := [][]any{
+		{"alice", now},
+	}
+	rows := NewRows(cols, values)
+
+	mock.ExpectQuery("SELECT name, created_at FROM users").WillReturnRows(rows)
+
+	returnRows, err := mock.Query(context.Background(), "SELECT name, created_at FROM users")
+	if err != nil {
+		t.Errorf("an error '%s' was not expected when querying", err)
+	}
+
+	if !returnRows.Next() {
+		t.Fatal("expected one row")
+	}
+
+	var name string
+	var createdAt time.Time
+	err = returnRows.Scan(&name, &createdAt)
+	if err != nil {
+		t.Errorf("an error '%s' was not expected when scanning", err)
+	}
+
+	if name != "alice" {
+		t.Errorf("expected name 'alice', got '%s'", name)
+	}
+
+	if !createdAt.Equal(now) {
+		t.Errorf("expected created_at %v, got %v", now, createdAt)
 	}
 }

--- a/rows.go
+++ b/rows.go
@@ -260,11 +260,8 @@ func NewRows(columns []ColumnType, values [][]any, opts ...RowsOption) *Rows {
 		reflectType := getReflectType(string(col.Type))
 		colTypes = append(colTypes, NewColumnType(col.Name, string(col.Type), false, reflectType))
 	}
-	block := &proto.Block{}
-	// Set timezone on block before adding columns
-	block.ServerContext = &column.ServerContext{
-		Timezone: options.timezone,
-	}
+	block := proto.NewBlock()
+	block.ServerContext.Timezone = options.timezone
 	for _, col := range columns {
 		err := block.AddColumn(col.Name, col.Type)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Replace `&proto.Block{}` with `proto.NewBlock()` in `NewRows` so that `ServerContext` is always properly initialized via the library's own constructor. The bare struct literal caused a nil pointer dereference when adding column types (e.g. `DateTime`) that dereference `sc.Timezone` in the prefix-match branch of `column_gen.go`.
- Fix four `fmt.Errorf(msg)` calls with non-constant format strings to `fmt.Errorf("%s", msg)`, satisfying the stricter vet check introduced in Go 1.26.
- Add a regression test (`TestNewRowsWithDateTimeColumn`) that creates mock rows with a `DateTime` column, queries them, and scans into `time.Time` — covering the previously panicking code path.